### PR TITLE
EasyRecyclerAdapter listener NullPointerException fixed

### DIFF
--- a/library/src/main/java/com/carlosdelachica/easyrecycleradapters/adapter/EasyRecyclerAdapter.java
+++ b/library/src/main/java/com/carlosdelachica/easyrecycleradapters/adapter/EasyRecyclerAdapter.java
@@ -137,7 +137,7 @@ public class EasyRecyclerAdapter extends RecyclerView.Adapter<EasyViewHolder> {
   public void setOnClickListener(final OnItemClickListener listener) {
     this.itemClickListener = new DebouncedOnClickListener() {
       @Override public boolean onDebouncedClick(View v, int position) {
-        listener.onItemClick(position, v);
+        if(listener != null) listener.onItemClick(position, v);
         return true;
       }
     };
@@ -146,7 +146,8 @@ public class EasyRecyclerAdapter extends RecyclerView.Adapter<EasyViewHolder> {
   public void setOnLongClickListener(final OnItemLongClickListener listener) {
     this.longClickListener = new DebouncedOnLongClickListener() {
       @Override public boolean onDebouncedClick(View v, int position) {
-        return listener.onLongItemClicked(position, v);
+        if(listener != null) return listener.onLongItemClicked(position, v);
+        return false;
       }
     };
   }

--- a/library/src/main/java/com/carlosdelachica/easyrecycleradapters/adapter/EasyRecyclerAdapter.java
+++ b/library/src/main/java/com/carlosdelachica/easyrecycleradapters/adapter/EasyRecyclerAdapter.java
@@ -137,7 +137,9 @@ public class EasyRecyclerAdapter extends RecyclerView.Adapter<EasyViewHolder> {
   public void setOnClickListener(final OnItemClickListener listener) {
     this.itemClickListener = new DebouncedOnClickListener() {
       @Override public boolean onDebouncedClick(View v, int position) {
-        if(listener != null) listener.onItemClick(position, v);
+        if(listener != null){
+          listener.onItemClick(position, v);
+        }
         return true;
       }
     };
@@ -146,7 +148,9 @@ public class EasyRecyclerAdapter extends RecyclerView.Adapter<EasyViewHolder> {
   public void setOnLongClickListener(final OnItemLongClickListener listener) {
     this.longClickListener = new DebouncedOnLongClickListener() {
       @Override public boolean onDebouncedClick(View v, int position) {
-        if(listener != null) return listener.onLongItemClicked(position, v);
+        if(listener != null){
+          return listener.onLongItemClicked(position, v);
+        }
         return false;
       }
     };


### PR DESCRIPTION
#9  When the EasyRecyclerViewManagerBuilder doesn't call clickListener or longClickListener and this event is called, happen this error.
